### PR TITLE
only check for a git rev if the src tree is in a git repo

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -2,30 +2,32 @@
 
 # Usage: version.sh <ffmpeg-root-dir> <output-version.h> <extra-version>
 
+if [ -d $1/.git ]; then  # only check for a git rev, if the src tree is in a git repo
 # check for git short hash
-if ! test "$revision"; then
+  if ! test "$revision"; then
     if (cd "$1" && grep git RELEASE 2> /dev/null >/dev/null) ; then
         revision=$(cd "$1" && git describe --tags --match N 2> /dev/null)
     else
         revision=$(cd "$1" && git describe --tags --always 2> /dev/null)
     fi
-fi
+  fi
 
-# Shallow Git clones (--depth) do not have the N tag:
-# use 'git-YYYY-MM-DD-hhhhhhh'.
-test "$revision" || revision=$(cd "$1" &&
-  git log -1 --pretty=format:"git-%cd-%h" --date=short 2> /dev/null)
+  # Shallow Git clones (--depth) do not have the N tag:
+  # use 'git-YYYY-MM-DD-hhhhhhh'.
+  test "$revision" || revision=$(cd "$1" &&
+    git log -1 --pretty=format:"git-%cd-%h" --date=short 2> /dev/null)
 
-# Snapshots from gitweb are in a directory called ffmpeg-hhhhhhh or
-# ffmpeg-HEAD-hhhhhhh.
-if [ -z "$revision" ]; then
-  srcdir=$(cd "$1" && pwd)
-  case "$srcdir" in
-    */ffmpeg-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-      git_hash="${srcdir##*-}";;
-    */ffmpeg-HEAD-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-      git_hash="${srcdir##*-}";;
-  esac
+  # Snapshots from gitweb are in a directory called ffmpeg-hhhhhhh or
+  # ffmpeg-HEAD-hhhhhhh.
+  if [ -z "$revision" ]; then
+    srcdir=$(cd "$1" && pwd)
+    case "$srcdir" in
+      */ffmpeg-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+        git_hash="${srcdir##*-}";;
+      */ffmpeg-HEAD-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+        git_hash="${srcdir##*-}";;
+    esac
+  fi
 fi
 
 # no revision number found


### PR DESCRIPTION
fixes the FFmpeg version string when building from the kodi depends src tree

not sure if this warrants a release bump and bump in kodi. I guess it can wait till next regular rebase.