### PR TITLE
make kodi versioning simpler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ GIT_LOG     = $(SRC_PATH)/.git/logs/HEAD
 .version: M=@
 
 libavutil/ffversion.h .version:
-	$(M)$(VERSION_SH) $(SRC_PATH) libavutil/ffversion.h $(EXTRA_VERSION)
+	$(M)$(VERSION_SH) $(SRC_PATH) libavutil/ffversion.h Kodi
 	$(Q)touch .version
 
 # force version.sh to run whenever version might have changed

--- a/ffbuild/common.mak
+++ b/ffbuild/common.mak
@@ -80,7 +80,7 @@ COMPILE_NVCC = $(call COMPILE,NVCC)
 
 %.o: %.asm
 	$(COMPILE_X86ASM)
-	-$(if $(ASMSTRIPFLAGS), $(STRIP) $(ASMSTRIPFLAGS) $@)
+	$(if $(STRIP), $(if $(ASMSTRIPFLAGS), $(STRIP) $(ASMSTRIPFLAGS) $@))
 
 %.o: %.rc
 	$(WINDRES) $(IFLAGS) --preprocessor "$(DEPWINDRES) -E -xc-header -DRC_INVOKED $(CC_DEPFLAGS)" -o $@ $<

--- a/ffbuild/version.sh
+++ b/ffbuild/version.sh
@@ -2,6 +2,7 @@
 
 # Usage: version.sh <ffmpeg-root-dir> <output-version.h> <extra-version>
 
+if [ -d $1/.git ]; then  # only check for a git rev, if the src tree is in a git repo
 # check for git short hash
 if ! test "$revision"; then
     if (cd "$1" && grep git RELEASE 2> /dev/null >/dev/null) ; then
@@ -26,6 +27,7 @@ if [ -z "$revision" ]; then
     */ffmpeg-HEAD-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
       git_hash="${srcdir##*-}";;
   esac
+fi
 fi
 
 # no revision number found

--- a/libavutil/utils.c
+++ b/libavutil/utils.c
@@ -32,7 +32,7 @@ const char av_util_ffversion[] = "FFmpeg version " FFMPEG_VERSION;
 
 const char *av_version_info(void)
 {
-    return "ffmpeg-3.4-kodi";
+    return FFMPEG_VERSION;
 }
 
 unsigned avutil_version(void)


### PR DESCRIPTION
With this change we don't have to update the return value in av_version_info after rebasing onto a new version.