### PR TITLE
avcodec/vaapi_h264: skip decode if pic has no slices

### DIFF
--- a/libavcodec/vaapi_h264.c
+++ b/libavcodec/vaapi_h264.c
@@ -317,6 +317,11 @@ static int vaapi_h264_end_frame(AVCodecContext *avctx)
     H264SliceContext *sl = &h->slice_ctx[0];
     int ret;
 
+    if (pic->nb_slices == 0) {
+        ret = AVERROR_INVALIDDATA;
+        goto finish;
+    }
+
     ret = ff_vaapi_decode_issue(avctx, pic);
     if (ret < 0)
         goto finish;


### PR DESCRIPTION
Fixes: https://github.com/xbmc/xbmc/issues/15704
Upstream: http://ffmpeg.org/pipermail/ffmpeg-devel/2019-March/240864.html

This should go into 18.2