### PR TITLE
[VideoToolbox] Force SW decoder for interlaced h264 videos on iOS/tvOS devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ GIT_LOG     = $(SRC_PATH)/.git/logs/HEAD
 .version: M=@
 
 libavutil/ffversion.h .version:
-	$(M)$(VERSION_SH) $(SRC_PATH) libavutil/ffversion.h $(EXTRA_VERSION)
+	$(M)$(VERSION_SH) $(SRC_PATH) libavutil/ffversion.h Kodi
 	$(Q)touch .version
 
 # force version.sh to run whenever version might have changed

--- a/ffbuild/common.mak
+++ b/ffbuild/common.mak
@@ -79,7 +79,7 @@ COMPILE_NVCC = $(call COMPILE,NVCC)
 
 %.o: %.asm
 	$(COMPILE_X86ASM)
-	-$(if $(ASMSTRIPFLAGS), $(STRIP) $(ASMSTRIPFLAGS) $@)
+	$(if $(STRIP), $(if $(ASMSTRIPFLAGS), $(STRIP) $(ASMSTRIPFLAGS) $@))
 
 %.o: %.rc
 	$(WINDRES) $(IFLAGS) --preprocessor "$(DEPWINDRES) -E -xc-header -DRC_INVOKED $(CC_DEPFLAGS)" -o $@ $<

--- a/ffbuild/version.sh
+++ b/ffbuild/version.sh
@@ -2,6 +2,7 @@
 
 # Usage: version.sh <ffmpeg-root-dir> <output-version.h> <extra-version>
 
+if [ -d $1/.git ]; then  # only check for a git rev, if the src tree is in a git repo
 # check for git short hash
 if ! test "$revision"; then
     if (cd "$1" && grep git RELEASE 2> /dev/null >/dev/null) ; then
@@ -26,6 +27,7 @@ if [ -z "$revision" ]; then
     */ffmpeg-HEAD-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
       git_hash="${srcdir##*-}";;
   esac
+fi
 fi
 
 # no revision number found

--- a/libavcodec/dxva2.c
+++ b/libavcodec/dxva2.c
@@ -771,16 +771,18 @@ unsigned ff_dxva2_get_surface_index(const AVCodecContext *avctx,
 #if CONFIG_D3D11VA
     if (avctx->pix_fmt == AV_PIX_FMT_D3D11)
         return (intptr_t)frame->data[1];
-    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD) {
+    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD && surface) {
         D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC viewDesc;
         ID3D11VideoDecoderOutputView_GetDesc((ID3D11VideoDecoderOutputView*) surface, &viewDesc);
         return viewDesc.Texture2D.ArraySlice;
     }
 #endif
 #if CONFIG_DXVA2
-    for (i = 0; i < DXVA_CONTEXT_COUNT(avctx, ctx); i++) {
-        if (avctx->pix_fmt == AV_PIX_FMT_DXVA2_VLD && ctx->dxva2.surface[i] == surface)
-            return i;
+    if (avctx->pix_fmt == AV_PIX_FMT_DXVA2_VLD) {
+        for (i = 0; i < DXVA_CONTEXT_COUNT(avctx, ctx); i++) {
+            if (ctx->dxva2.surface[i] == surface)
+                return i;
+        }
     }
 #endif
 

--- a/libavcodec/dxva2_h264.c
+++ b/libavcodec/dxva2_h264.c
@@ -504,6 +504,14 @@ static int dxva2_h264_end_frame(AVCodecContext *avctx)
 
     if (ctx_pic->slice_count <= 0 || ctx_pic->bitstream_size <= 0)
         return -1;
+
+    // Wait for an I-frame before start decoding. Workaround for ATI UVD and UVD+ GPUs
+    if (!h->got_first_iframe) {
+        if (!(ctx_pic->pp.wBitFields & (1 << 15)))
+            return -1;
+        h->got_first_iframe = 1;
+    }
+
     ret = ff_dxva2_common_end_frame(avctx, h->cur_pic_ptr->f,
                                     &ctx_pic->pp, sizeof(ctx_pic->pp),
                                     &ctx_pic->qm, sizeof(ctx_pic->qm),

--- a/libavcodec/h264_slice.c
+++ b/libavcodec/h264_slice.c
@@ -928,6 +928,7 @@ static int h264_slice_header_init(H264Context *h)
 
     h->first_field           = 0;
     h->prev_interlaced_frame = 1;
+    h->got_first_iframe = 0;
 
     init_scan_tables(h);
     ret = ff_h264_alloc_tables(h);

--- a/libavcodec/h264dec.c
+++ b/libavcodec/h264dec.c
@@ -467,6 +467,7 @@ void ff_h264_flush_change(H264Context *h)
 
     h->next_outputed_poc = INT_MIN;
     h->prev_interlaced_frame = 1;
+    h->got_first_iframe = 0;
     idr(h);
 
     h->poc.prev_frame_num = -1;

--- a/libavcodec/h264dec.h
+++ b/libavcodec/h264dec.h
@@ -539,6 +539,8 @@ typedef struct H264Context {
      * slices) anymore */
     int setup_finished;
 
+    int got_first_iframe;
+
     int cur_chroma_format_idc;
     int cur_bit_depth_luma;
     int16_t slice_row[MAX_SLICES]; ///< to detect when MAX_SLICES is too low

--- a/libavcodec/vaapi_h264.c
+++ b/libavcodec/vaapi_h264.c
@@ -314,6 +314,11 @@ static int vaapi_h264_end_frame(AVCodecContext *avctx)
     H264SliceContext *sl = &h->slice_ctx[0];
     int ret;
 
+    if (pic->nb_slices == 0) {
+        ret = AVERROR_INVALIDDATA;
+        goto finish;
+    }
+
     ret = ff_vaapi_decode_issue(avctx, pic);
     if (ret < 0)
         goto finish;

--- a/libavcodec/videotoolbox.c
+++ b/libavcodec/videotoolbox.c
@@ -743,11 +743,18 @@ static CFDictionaryRef videotoolbox_decoder_config_create(CMVideoCodecType codec
         if (data)
             CFDictionarySetValue(avc_info, CFSTR("esds"), data);
         break;
-    case kCMVideoCodecType_H264 :
+    case kCMVideoCodecType_H264 : {
+        H264Context *h = avctx->priv_data;
+        if (TARGET_OS_IPHONE && h->ps.sps->frame_mbs_only_flag == 0) {
+            av_log(avctx, AV_LOG_ERROR, "VideoToolbox cannot decode interlaced fields on iOS\n");
+            CFRelease(avc_info);
+            goto fail;
+        }
         data = ff_videotoolbox_avcc_extradata_create(avctx);
         if (data)
             CFDictionarySetValue(avc_info, CFSTR("avcC"), data);
         break;
+    }
     case kCMVideoCodecType_HEVC :
         data = ff_videotoolbox_hvcc_extradata_create(avctx);
         if (data)
@@ -766,6 +773,10 @@ static CFDictionaryRef videotoolbox_decoder_config_create(CMVideoCodecType codec
 
     CFRelease(avc_info);
     return config_info;
+
+fail:
+    CFRelease(config_info);
+    return NULL;
 }
 
 static int videotoolbox_start(AVCodecContext *avctx)

--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -2562,6 +2562,10 @@ static void eit_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     const uint8_t *p, *p_end;
     SectionHeader h1, *h = &h1;
 
+    // Something in kodi breaks with seeking when EIT EPG data is included in the stream
+    // As we figure this out lets just skip any EIT data.
+    return;
+
     /*
      * Sometimes we receive EPG packets but SDT table do not have
      * eit_pres_following or eit_sched turned on, so we open EPG


### PR DESCRIPTION
On iOS and tvOS devices VideoToolbox is not able to correctly decode some interlaced h264 videos.
But on macOS everything works fine.

This patch, found here https://patchwork.ffmpeg.org/project/ffmpeg/patch/20170926003631.55571-3-ffmpeg@tmm1.net/#16694 (thank you @tmm1), force FFMPEG to use SW decoding in the special case "iOS/tvOS + interlaced h264 video".

This path will fix the issue given here https://github.com/xbmc/xbmc/issues/18287