### PR TITLE
avformat/mpegts: make sure mpegts_read_header always stops at the first pmt

### DIFF
--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -2352,7 +2352,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         goto out;
 
     // stop parsing after pmt, we found header
-    if (!ts->stream->nb_streams)
+    if (!ts->pkt)
         ts->stop_parse = 2;
 
     set_pmt_found(ts, h->id);


### PR DESCRIPTION
Long story short, the inclusion of EPG data streams in mpegts data streams here: https://github.com/FFmpeg/FFmpeg/commit/a221af1f5eea7313472b1cbeaa566b66d025fea6

Caused an issue where stream opening times can go from 2 secs to 10-15 secs for stream containing embedded (EIT) data.

When raised to the FFmpeg team this solution was proposed immediately. Here it is from the ffmpeg-devel list: http://ffmpeg.org/pipermail/ffmpeg-devel/2020-November/272422.html

@lrusak Any chance we can have this quickly added for beta1? @DaveTBlake if I'm not in time no worries!